### PR TITLE
Fix Development Server URL Display for IPv6 (#19)

### DIFF
--- a/src/handlers/_getDevServerUrl.ts
+++ b/src/handlers/_getDevServerUrl.ts
@@ -1,8 +1,8 @@
-import type { AddressInfo } from 'net'
-import type { ResolvedConfig } from 'vite'
-
 import { HTTP_PROTOCOLS } from '@config/http'
 import { isIpv6 } from '@utils/uri'
+
+import type { AddressInfo } from 'node:net'
+import type { ResolvedConfig } from 'vite'
 
 export const _getDevServerUrl = (address: AddressInfo, config: ResolvedConfig): string => {
 	const configHmrProtocol =
@@ -24,5 +24,5 @@ export const _getDevServerUrl = (address: AddressInfo, config: ResolvedConfig): 
 		typeof config.server.hmr === 'object' ? config.server.hmr.clientPort : null
 	const port = configHmrClientPort ?? address.port
 
-	return config.server?.origin ?? `${protocol}://${host}:${port}`
+	return config.server?.origin ?? `${protocol}://${host === '[::1]' ? 'localhost' : host}:${port}`
 }


### PR DESCRIPTION
This pull request addresses an issue where the plugin displayed [::1] instead of localhost in the development server URL when using IPv6.

- The `_getDevServerUrl` function is updated to handle this scenario.
- If the host address is identified as `[::1]`, it's replaced with `localhost` when constructing the development server URL.
- This change improves clarity and user experience by displaying the familiar `localhost` address during local development.